### PR TITLE
Improve appearance of scroll bar

### DIFF
--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -72,8 +72,9 @@ form {
 
   /* wanted this container to be scrollable so the demo never goes out of sight */
   max-height: 100vh;
-  overflow-y: scroll;
+  overflow-y: auto;
   padding-top: 0.5rem; /* floating label was getting cutoff */
+  padding-right: 0.5rem;
 }
 form > :global(*) {
   margin-bottom: 1rem;


### PR DESCRIPTION
This hides the scroll bar when it's not needed, and gives a little breathing room between it and the input fields when the scrollbar is needed.