### PR TITLE
begin migration to host on Cloudflare pages

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,3 +39,15 @@ data "cloudflare_zones" "domain" {
     status      = "active"
   }
 }
+
+module "pages" {
+  source  = "silinternational/pages/cloudflare"
+  version = "0.2.0"
+
+  cloudflare_account_id = var.cloudflare_account_id
+  project_name          = var.project_name
+  repo_name             = var.repo_name
+  repo_owner            = var.repo_owner
+  domain                = var.cloudflare_domain
+  subdomain             = var.pages_subdomain
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -8,14 +8,6 @@ variable "aws_access_key" {
 variable "aws_secret_key" {
 }
 
-variable "cloudflare_token" {
-  description = "The Cloudflare API token. This is an alternative to email+api_key. If both are specified, api_token will be used over email+api_key fields."
-  default     = ""
-}
-
-variable "cloudflare_domain" {
-}
-
 variable "app_bucket_name" {
 }
 
@@ -55,3 +47,46 @@ variable "app_name" {
   type        = string
   default     = "email-signature-generator"
 }
+
+/*
+ * Cloudflare Pages variables
+ */
+variable "cloudflare_account_id" {
+  description = "Cloudflare account number"
+  type        = string
+}
+
+variable "cloudflare_domain" {
+  description = "DNS domain on Cloudflare"
+  type        = string
+}
+
+variable "cloudflare_token" {
+  description = "The Cloudflare API token"
+  type        = string
+  default     = ""
+}
+
+variable "project_name" {
+  description = "Cloudflare Pages project name"
+  type        = string
+  default     = "email-signature-generator"
+}
+
+variable "repo_name" {
+  description = "GitHub repository name"
+  type        = string
+  default     = "email-signature-generator"
+}
+
+variable "repo_owner" {
+  description = "GitHub repository owner"
+  type        = string
+  default     = "silinternational"
+}
+
+variable "pages_subdomain" {
+  description = "DNS subdomain for hosting the Cloudflare Pages project"
+  type        = string
+}
+


### PR DESCRIPTION
Expected migration steps:
1. Create Cloudflare Pages project on a separate subdomain (this PR)
2. Move to the final subdomain, directing traffic to the Pages project
3. Delete AWS S3 bucket and Cloudfront Distribution