### PR TITLE
remove aws provider

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -23,26 +23,3 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
     "zh:e9bcf26c44dd231f74703b6a6717470021a3ba7e1d7531dcf7287a6441300e27",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.67.0"
-  constraints = ">= 4.0.0, ~> 4.0, < 5.0.0"
-  hashes = [
-    "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
-    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
-    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
-    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
-    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
-    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
-    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
-    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
-    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
-    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
-    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
-    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
-    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
-    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
-  ]
-}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,8 +1,3 @@
-provider "aws" {
-  region     = var.aws_region
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
-}
 
 provider "cloudflare" {
   api_token = var.cloudflare_token

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,16 +1,4 @@
-variable "aws_region" {
-  default = "us-east-1"
-}
 
-variable "aws_access_key" {
-}
-
-variable "aws_secret_key" {
-}
-
-/*
- * Cloudflare Pages variables
- */
 variable "cloudflare_account_id" {
   description = "Cloudflare account number"
   type        = string

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -2,10 +2,6 @@
 terraform {
   required_version = ">= 1.0"
   required_providers {
-    aws = {
-      version = "~> 4.0"
-      source  = "hashicorp/aws"
-    }
     cloudflare = {
       version = "~> 3.0"
       source  = "cloudflare/cloudflare"


### PR DESCRIPTION
Now that the AWS resources have been removed from the Terraform state, the provider itself can be removed.